### PR TITLE
[revert-datetimetype-changes] Revert changes to DateTimeType.

### DIFF
--- a/src/Type/DatetimeType.php
+++ b/src/Type/DatetimeType.php
@@ -38,6 +38,6 @@ class DatetimeType implements TypeInterface
         $date = DateTime::createFromFormat($this->datetimeFormat, $value, new DateTimeZone($this->datetimeZone));
         $errors = DateTime::getLastErrors();
 
-        return $date && !$errors;
+        return $date && $errors['warning_count'] === 0 && $errors['error_count'] === 0;
     }
 }


### PR DESCRIPTION
DateTime::getLastErrors() is only 'false' if there was never a DateTime object initialized beforehand. This is actually a documentation issue: https://github.com/php/doc-en/issues/1351